### PR TITLE
chore(ui): fix tests

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,6 +30,7 @@
     "@babel/preset-env": "^7.3.1",
     "@babel/runtime": "^7.3.1",
     "@vue/test-utils": "^1.0.0-beta.28",
+    "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.6.0",
     "babel-plugin-dynamic-import-node": "^2.2.0",
     "find": "^0.2.9",

--- a/packages/ui/yarn.lock
+++ b/packages/ui/yarn.lock
@@ -608,10 +608,10 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@endpass/utils@^1.0.10":
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/@endpass/utils/-/utils-1.0.10.tgz#9f338ff9160f757b67f7d5504fcd646675d5368c"
-  integrity sha512-+yntssNyhy4f1u4gWU7O10d7yQsAQxAO9ZsU6dgZr6dtQNOri19oZM2G7wtNFCJ/ERDBTlNVW7jkbRz/XzYrRw==
+"@endpass/utils@^1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@endpass/utils/-/utils-1.0.11.tgz#0cccd476acc619c50a039cd3ffbda18a726262da"
+  integrity sha512-2N5ZxR2N7yOgRZlp8aGFJWgvKVG7fTylB5UZ3FubYu9KZ6UgLg0WP2jr2RkxTzEcNegkIJ7NxcCRRhIG4WC+0Q==
   dependencies:
     bs58check "^2.1.2"
     dayjs "^1.7.8"
@@ -937,6 +937,11 @@ babel-core@^6.0.0, babel-core@^6.26.0:
     private "^0.1.8"
     slash "^1.0.0"
     source-map "^0.5.7"
+
+babel-core@^7.0.0-bridge.0:
+  version "7.0.0-bridge.0"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
+  integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
 
 babel-generator@^6.18.0, babel-generator@^6.26.0:
   version "6.26.1"


### PR DESCRIPTION
jest@24.0.0 должен работать с babel 7 из коробки (https://github.com/facebook/jest/blob/master/CHANGELOG.md#fixes-1), но подкачал vue-jest. Поэтому пока без babel-core@^7.0.0-bridge.0 не обойтись