### PR TITLE
Fix key of standard wallet type

### DIFF
--- a/packages/class/package.json
+++ b/packages/class/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endpass/class",
-  "version": "0.14.7",
+  "version": "0.15.0",
   "description": "Class modules",
   "author": "Endpass, Inc",
   "homepage": "http://endpass.com/",

--- a/packages/class/src/wallet/types.js
+++ b/packages/class/src/wallet/types.js
@@ -4,7 +4,7 @@ export const HARDWARE_WALLET_TYPE = Object.freeze({
 });
 
 export const WALLET_TYPE = Object.freeze({
-  STANDART: 'StandardAccount',
+  STANDARD: 'StandardAccount',
   PUBLIC: 'PublicAccount',
   HD_PUBLIC: 'HDPublicAccount',
   HD_MAIN: 'HDMainAccount',


### PR DESCRIPTION
BREAKING CHANGE: update key of standard wallet type

Before:

const WALLET_TYPES = Wallet.getTypes();
const standardType = WALLET_TYPES.STANDART;

After:

const WALLET_TYPES = Wallet.getTypes();
const standardType = WALLET_TYPES.STANDARD;
