### PR TITLE
refactor(utils): made new type for `scrypt` literal, refactor keystore types

### DIFF
--- a/packages/utils/types/constants.d.ts
+++ b/packages/utils/types/constants.d.ts
@@ -1,0 +1,11 @@
+declare type KDFEncryptScryptProperty = 'scrypt';
+
+declare type KDFEncryptOptions = {
+  kdf: KDFEncryptScryptProperty,
+  n: number,
+};
+
+declare module '@endpass/utils/constants' {
+  export const KDF_ENCRYPT_OPTIONS: KDFEncryptOptions;
+  export const HD_KEY_MNEMONIC_PATH: "m/44'/60'/0'/0";
+}

--- a/packages/utils/types/ethereum.d.ts
+++ b/packages/utils/types/ethereum.d.ts
@@ -1,0 +1,15 @@
+declare class Wallet {
+  static fromPrivateKey(key: Buffer): Wallet;
+  static fromV3(json: string, password: string): Wallet;
+  getPrivateKey(): Buffer;
+  getAddressString(): string;
+  getChecksumAddressString(): string;
+}
+
+declare class EthereumHDKey {
+  privateExtendedKey (): string;
+  publicExtendedKey (): string;
+  derivePath (path: string): EthereumHDKey;
+  deriveChild (index: number): EthereumHDKey;
+  getWallet (): Wallet;
+}

--- a/packages/utils/types/keystoreCrypto.d.ts
+++ b/packages/utils/types/keystoreCrypto.d.ts
@@ -6,10 +6,10 @@ declare module '@endpass/utils/keystoreCrypto' {
     password: string,
     privateKey: string | Buffer,
     options: KDFEncryptOptions
-  ): v3KeystoreWithoutAddress;
+  ): V3KeystoreWithoutAddress;
 
   export function decrypt(
     password: string,
-    v3Keystore: v3Keystore
+    v3Keystore: V3Keystore
   ): Buffer;
 }

--- a/packages/utils/types/keystoreCrypto.d.ts
+++ b/packages/utils/types/keystoreCrypto.d.ts
@@ -1,0 +1,15 @@
+/// <reference path="constants.d.ts" />
+/// <reference path="keystores.d.ts" />
+
+declare module '@endpass/utils/keystoreCrypto' {
+  export function encrypt(
+    password: string,
+    privateKey: string | Buffer,
+    options: KDFEncryptOptions
+  ): v3KeystoreWithoutAddress;
+
+  export function decrypt(
+    password: string,
+    v3Keystore: v3Keystore
+  ): Buffer;
+}

--- a/packages/utils/types/keystoreHDWallet.d.ts
+++ b/packages/utils/types/keystoreHDWallet.d.ts
@@ -9,10 +9,10 @@ declare module '@endpass/utils/keystoreHDWallet' {
     password: string,
     wallet: EthereumHDKey,
     encryptOptions: KDFEncryptOptions
-  ): v3Keystore;
+  ): V3Keystore;
 
   export function decryptHDWallet(
     password: string,
-    v3Keystore: v3Keystore
+    v3Keystore: V3Keystore
   ): EthereumHDKey;
 }

--- a/packages/utils/types/keystoreHDWallet.d.ts
+++ b/packages/utils/types/keystoreHDWallet.d.ts
@@ -1,0 +1,18 @@
+/// <reference path="constants.d.ts" />
+/// <reference path="ethereum.d.ts" />
+/// <reference path="keystores.d.ts" />
+
+declare module '@endpass/utils/keystoreHDWallet' {
+  export function createHDWalletBySeed(seedPhrase: string): EthereumHDKey;
+
+  export function encryptHDWallet(
+    password: string,
+    wallet: EthereumHDKey,
+    encryptOptions: KDFEncryptOptions
+  ): v3Keystore;
+
+  export function decryptHDWallet(
+    password: string,
+    v3Keystore: v3Keystore
+  ): EthereumHDKey;
+}

--- a/packages/utils/types/keystoreKeyGen.d.ts
+++ b/packages/utils/types/keystoreKeyGen.d.ts
@@ -1,0 +1,6 @@
+/// <reference path="keystores.d.ts" />
+
+declare module '@endpass/utils/keystoreKeyGen' {
+  export function getPublicKey(password: string, v3Keystore: v3Keystore): string;
+  export function getPrivateKey(password: string, v3Keystore: v3Keystore): string;
+}

--- a/packages/utils/types/keystoreKeyGen.d.ts
+++ b/packages/utils/types/keystoreKeyGen.d.ts
@@ -1,6 +1,6 @@
 /// <reference path="keystores.d.ts" />
 
 declare module '@endpass/utils/keystoreKeyGen' {
-  export function getPublicKey(password: string, v3Keystore: v3Keystore): string;
-  export function getPrivateKey(password: string, v3Keystore: v3Keystore): string;
+  export function getPublicKey(password: string, v3Keystore: V3Keystore): string;
+  export function getPrivateKey(password: string, v3Keystore: V3Keystore): string;
 }

--- a/packages/utils/types/keystoreWallet.d.ts
+++ b/packages/utils/types/keystoreWallet.d.ts
@@ -5,7 +5,7 @@
 declare module '@endpass/utils/keystoreWallet' {
   export function createWalletByIndex(
     password: string,
-    hdKeystore: v3Keystore,
+    hdKeystore: V3Keystore,
     index?: number
   ): Wallet;
 
@@ -13,10 +13,10 @@ declare module '@endpass/utils/keystoreWallet' {
     password: string,
     wallet: Wallet,
     encryptOptions: KDFEncryptOptions
-  ): v3Keystore;
+  ): V3Keystore;
 
   export function decryptWallet(
     password: string,
-    v3Keystore: v3Keystore
+    v3Keystore: V3Keystore
   ): Wallet;
 }

--- a/packages/utils/types/keystoreWallet.d.ts
+++ b/packages/utils/types/keystoreWallet.d.ts
@@ -1,0 +1,22 @@
+/// <reference path="constants.d.ts" />
+/// <reference path="ethereum.d.ts" />
+/// <reference path="keystores.d.ts" />
+
+declare module '@endpass/utils/keystoreWallet' {
+  export function createWalletByIndex(
+    password: string,
+    hdKeystore: v3Keystore,
+    index?: number
+  ): Wallet;
+
+  export function encryptWallet(
+    password: string,
+    wallet: Wallet,
+    encryptOptions: KDFEncryptOptions
+  ): v3Keystore;
+
+  export function decryptWallet(
+    password: string,
+    v3Keystore: v3Keystore
+  ): Wallet;
+}

--- a/packages/utils/types/keystores.d.ts
+++ b/packages/utils/types/keystores.d.ts
@@ -28,7 +28,7 @@ declare namespace _ {
 }
 
 // Keystore types
-declare type v3Keystore = {
+declare type V3Keystore = {
   crypto: {
     kdfparams: {
       dklen: number,
@@ -40,7 +40,7 @@ declare type v3Keystore = {
   },
 } & _.BasicAddressedKeystore;
 
-declare type v3KeystoreWithoutAddress = {
+declare type V3KeystoreWithoutAddress = {
   crypto: {
     kdfparams: {
       dklen: number,

--- a/packages/utils/types/keystores.d.ts
+++ b/packages/utils/types/keystores.d.ts
@@ -1,0 +1,53 @@
+// Private unexported namespace which visible only within this file
+declare namespace _ {
+  // Common template type for key stores
+  type BasicKeystore = {
+    id: string,
+    version: 3,
+
+    crypto: {
+      cipher: string,
+      ciphertext: string,
+      cipherparams: {
+        iv: string,
+      },
+      mac: string,
+      kdf: string,
+
+      // In the basic key store kdfparams may accept any object value
+      // Note that this is common, generic type which should not be used
+      // out of bounds of this file
+      kdfparams: object,
+    },
+  };
+
+  // Common template type for addressed keystores
+  type BasicAddressedKeystore = {
+    address: string,
+  } & BasicKeystore;
+}
+
+// Keystore types
+declare type v3Keystore = {
+  crypto: {
+    kdfparams: {
+      dklen: number,
+      n: number,
+      r: number,
+      p: number,
+      salt: string,
+    },
+  },
+} & _.BasicAddressedKeystore;
+
+declare type v3KeystoreWithoutAddress = {
+  crypto: {
+    kdfparams: {
+      dklen: number,
+      n: number,
+      r: number,
+      p: number,
+      salt: string,
+    },
+  },
+} & _.BasicKeystore;

--- a/packages/utils/types/walletGen.d.ts
+++ b/packages/utils/types/walletGen.d.ts
@@ -8,8 +8,8 @@ declare module "@endpass/utils/walletGen" {
   ): Promise<{
     seedKey: string,
     encryptedSeed: string,
-    v3KeystoreHdWallet: v3Keystore,
-    v3KeystoreChildWallet: v3Keystore,
+    v3KeystoreHdWallet: V3Keystore,
+    v3KeystoreChildWallet: V3Keystore,
   }>;
 
   export function createHDWithChild(
@@ -17,7 +17,7 @@ declare module "@endpass/utils/walletGen" {
     password: string,
     encryptOptions: KDFEncryptOptions,
   ): {
-    v3KeystoreHdWallet: v3Keystore,
-    v3KeystoreChildWallet: v3Keystore,
+    v3KeystoreHdWallet: V3Keystore,
+    v3KeystoreChildWallet: V3Keystore,
   };
 }

--- a/packages/utils/types/walletGen.d.ts
+++ b/packages/utils/types/walletGen.d.ts
@@ -1,0 +1,23 @@
+/// <reference path="constants.d.ts" />
+/// <reference path="keystores.d.ts" />
+
+declare module "@endpass/utils/walletGen" {
+  export function createComplex(
+    password: string,
+    encryptOptions: KDFEncryptOptions
+  ): Promise<{
+    seedKey: string,
+    encryptedSeed: string,
+    v3KeystoreHdWallet: v3Keystore,
+    v3KeystoreChildWallet: v3Keystore,
+  }>;
+
+  export function createHDWithChild(
+    seedKey: string,
+    password: string,
+    encryptOptions: KDFEncryptOptions,
+  ): {
+    v3KeystoreHdWallet: v3Keystore,
+    v3KeystoreChildWallet: v3Keystore,
+  };
+}


### PR DESCRIPTION
- Did rename `v3Keystore` to the `V3Keystore`
- Made new, stand-alone and separated type `KDFEncryptOptionsScryptProperty` instead of `scrypt` literal for more DRY codebase
- Remove global.d.ts in favor of well-scoped, separated declaration files which should be imported explicitly