### PR TITLE
Feature: New skins for ui

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endpass/ui",
-  "version": "0.15.74",
+  "version": "0.15.75",
   "description": "UI components",
   "author": "Endpass, Inc",
   "homepage": "http://endpass.com/",

--- a/packages/ui/src/kit/VButton/VButton.theme-default.scss
+++ b/packages/ui/src/kit/VButton/VButton.theme-default.scss
@@ -17,10 +17,6 @@
   width: auto;
 }
 
-.v-button.theme-default.is-borderless {
-  border: 0 none;
-}
-
 .v-button.theme-default .v-button-label {
   text-transform: uppercase;
   font-size: 14px;
@@ -229,10 +225,43 @@
   box-shadow: none;
 }
 
-.v-button.skin-text-primary {
-  color: var(--endpass-ui-color-primary-7);
-  border-color: var(--endpass-ui-color-primary-7);
+
+
+
+
+
+
+
+
+.v-button.skin-ghost-error {
   box-shadow: none;
+  border-color: transparent;
+  color: var(--endpass-ui-color-error);
+}
+
+.v-button.theme-default.skin-ghost-error .v-button-label {
+  color: var(--endpass-ui-color-error);
+}
+
+.v-button.theme-default.skin-ghost-error:hover {
+  background: var(--endpass-ui-color-grey-2);
+}
+
+.v-button.theme-default.skin-ghost-error:focus {
+  border-color: var(--endpass-ui-color-error);
+}
+
+.v-button.theme-default.skin-ghost-error:active {
+  border-color: transparent;
+  background: var(--endpass-ui-color-grey-3);
+}
+
+.v-button.theme-default.skin-ghost:active .v-button-label {
+  color: var(--endpass-ui-color-white);
+}
+
+.v-button.theme-default.skin-ghost .svg-atom {
+  fill: var(--endpass-ui-color-error);
 }
 
 .v-button.theme-default.skin-social {

--- a/packages/ui/src/kit/VButton/VButton.theme-default.scss
+++ b/packages/ui/src/kit/VButton/VButton.theme-default.scss
@@ -229,7 +229,7 @@
   box-shadow: none;
 }
 
-.v-button.skin-quaternary-primary {
+.v-button.skin-text-primary {
   color: var(--endpass-ui-color-primary-7);
   border-color: var(--endpass-ui-color-primary-7);
   box-shadow: none;

--- a/packages/ui/src/kit/VButton/VButton.theme-default.scss
+++ b/packages/ui/src/kit/VButton/VButton.theme-default.scss
@@ -17,6 +17,10 @@
   width: auto;
 }
 
+.v-button.theme-default.is-borderless {
+  border: 0 none;
+}
+
 .v-button.theme-default .v-button-label {
   text-transform: uppercase;
   font-size: 14px;
@@ -222,6 +226,12 @@
 .v-button.skin-quaternary-error {
   color: var(--endpass-ui-color-error);
   border-color: var(--endpass-ui-color-error);
+  box-shadow: none;
+}
+
+.v-button.skin-quaternary-primary {
+  color: var(--endpass-ui-color-primary-7);
+  border-color: var(--endpass-ui-color-primary-7);
   box-shadow: none;
 }
 

--- a/packages/ui/src/kit/VButton/VButton.vue
+++ b/packages/ui/src/kit/VButton/VButton.vue
@@ -67,7 +67,7 @@ export default {
             'success',
             'error',
             'quaternary-error',
-            'text-primary',
+            'ghost-error',
           ].indexOf(value) !== -1
         );
       },
@@ -77,10 +77,6 @@ export default {
       default: false,
     },
     isInline: {
-      type: Boolean,
-      default: false,
-    },
-    isBorderless: {
       type: Boolean,
       default: false,
     },
@@ -99,7 +95,6 @@ export default {
         [`skin-${this.skin}`]: true,
         [`size-${this.size}`]: true,
         'is-inline': this.isInline,
-        'is-borderless': this.isBorderless,
       };
     },
     isSocialIcon() {

--- a/packages/ui/src/kit/VButton/VButton.vue
+++ b/packages/ui/src/kit/VButton/VButton.vue
@@ -67,7 +67,7 @@ export default {
             'success',
             'error',
             'quaternary-error',
-            'quaternary-primary',
+            'text-primary',
           ].indexOf(value) !== -1
         );
       },

--- a/packages/ui/src/kit/VButton/VButton.vue
+++ b/packages/ui/src/kit/VButton/VButton.vue
@@ -67,6 +67,7 @@ export default {
             'success',
             'error',
             'quaternary-error',
+            'quaternary-primary',
           ].indexOf(value) !== -1
         );
       },
@@ -76,6 +77,10 @@ export default {
       default: false,
     },
     isInline: {
+      type: Boolean,
+      default: false,
+    },
+    isBorderless: {
       type: Boolean,
       default: false,
     },
@@ -94,6 +99,7 @@ export default {
         [`skin-${this.skin}`]: true,
         [`size-${this.size}`]: true,
         'is-inline': this.isInline,
+        'is-borderless': this.isBorderless,
       };
     },
     isSocialIcon() {

--- a/packages/ui/src/kit/VTag/VTag.theme-default.scss
+++ b/packages/ui/src/kit/VTag/VTag.theme-default.scss
@@ -83,6 +83,12 @@
   background-color: var(--endpass-ui-color-grey-1);
 }
 
+.v-tag.theme-default.skin-white {
+  border-color: var(--endpass-ui-color-grey-3);
+  color: var(--endpass-ui-color-grey-9);
+  background-color: transparent;
+}
+
 .v-tag.theme-default[disabled] {
   background-color: var(--endpass-ui-color-grey-1);
   color: var(--endpass-ui-color-grey-4);

--- a/packages/ui/src/kit/VTag/VTag.vue
+++ b/packages/ui/src/kit/VTag/VTag.vue
@@ -44,6 +44,7 @@ export default {
             'green',
             'gray',
             'light-gray',
+            'white',
           ].indexOf(value) !== -1
         );
       },

--- a/packages/ui/stories/VButton.stories.js
+++ b/packages/ui/stories/VButton.stories.js
@@ -26,6 +26,7 @@ storiesOf('VButton/desktop', module)
               <th>Tertiary</th>
               <th>Quaternary</th>
               <th>Ghost</th>
+              <th>Text Primary</th>
             </tr>
           </thead>
           <tbody>
@@ -36,6 +37,7 @@ storiesOf('VButton/desktop', module)
               <td><v-button @focus="onFocus" skin="tertiary">Button Label</v-button></td>
               <td><v-button @blur="onBlur" skin="quaternary">Button Label</v-button></td>
               <td><v-button @mouseleave="onLeave" skin="ghost">Button Label</v-button></td>
+              <td><v-button @mouseleave="onLeave" skin="text-primary">Button Label</v-button></td>
             </tr>
             <tr>
               <th scope="row">Big</th>
@@ -44,6 +46,7 @@ storiesOf('VButton/desktop', module)
               <td><v-button @focus="onFocus" skin="tertiary" size="big">Button Label</v-button></td>
               <td><v-button @blur="onBlur" skin="quaternary" size="big">Button Label</v-button></td>
               <td><v-button @mouseleave="onLeave" skin="ghost" size="big">Button Label</v-button></td>
+              <td><v-button @mouseleave="onLeave" skin="text-primary" size="big">Button Label</v-button></td>
             </tr>
           </tbody>
         </table>
@@ -63,6 +66,7 @@ storiesOf('VButton/desktop', module)
           'success',
           'error',
           'quaternary-error',
+          'text-primary',
         ],
         skin: 'primary',
       };
@@ -308,6 +312,44 @@ storiesOf('VButton/desktop', module)
               <td><v-button disabled @focus="onFocus" skin="tertiary" size="big">Button Label</v-button></td>
               <td><v-button disabled @blur="onBlur" skin="quaternary" size="big">Button Label</v-button></td>
               <td><v-button disabled @mouseleave="onLeave" skin="ghost" size="big">Button Label</v-button></td>
+            </tr>
+          </tbody>
+        </table>
+      </theme-provider>
+    `,
+  }))
+  .add('borderless', () => ({
+    methods,
+    components: { VButton },
+    template: `
+      <theme-provider>
+        <table width="100%">
+          <thead>
+            <tr>
+              <th></th>
+              <th>Primary</th>
+              <th>Secondary</th>
+              <th>Tertiary</th>
+              <th>Quaternary</th>
+              <th>Ghost</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">Normal</th>
+              <td><v-button :isBorderless="true" @click="onClick">Button Label</v-button></td>
+              <td><v-button :isBorderless="true" @mouseenter="onEnter" skin="secondary">Button Label</v-button></td>
+              <td><v-button :isBorderless="true" @focus="onFocus" skin="tertiary">Button Label</v-button></td>
+              <td><v-button :isBorderless="true" @blur="onBlur" skin="quaternary">Button Label</v-button></td>
+              <td><v-button :isBorderless="true" @mouseleave="onLeave" skin="ghost">Button Label</v-button></td>
+            </tr>
+            <tr>
+              <th scope="row">Big</th>
+              <td><v-button :isBorderless="true" @click="onClick" size="big">Button Label</v-button></td>
+              <td><v-button :isBorderless="true" @mouseenter="onEnter" skin="secondary" size="big">Button Label</v-button></td>
+              <td><v-button :isBorderless="true" @focus="onFocus" skin="tertiary" size="big">Button Label</v-button></td>
+              <td><v-button :isBorderless="true" @blur="onBlur" skin="quaternary" size="big">Button Label</v-button></td>
+              <td><v-button :isBorderless="true" @mouseleave="onLeave" skin="ghost" size="big">Button Label</v-button></td>
             </tr>
           </tbody>
         </table>

--- a/packages/ui/stories/VButton.stories.js
+++ b/packages/ui/stories/VButton.stories.js
@@ -26,7 +26,6 @@ storiesOf('VButton/desktop', module)
               <th>Tertiary</th>
               <th>Quaternary</th>
               <th>Ghost</th>
-              <th>Text Primary</th>
             </tr>
           </thead>
           <tbody>
@@ -37,7 +36,6 @@ storiesOf('VButton/desktop', module)
               <td><v-button @focus="onFocus" skin="tertiary">Button Label</v-button></td>
               <td><v-button @blur="onBlur" skin="quaternary">Button Label</v-button></td>
               <td><v-button @mouseleave="onLeave" skin="ghost">Button Label</v-button></td>
-              <td><v-button @mouseleave="onLeave" skin="text-primary">Button Label</v-button></td>
             </tr>
             <tr>
               <th scope="row">Big</th>
@@ -46,7 +44,6 @@ storiesOf('VButton/desktop', module)
               <td><v-button @focus="onFocus" skin="tertiary" size="big">Button Label</v-button></td>
               <td><v-button @blur="onBlur" skin="quaternary" size="big">Button Label</v-button></td>
               <td><v-button @mouseleave="onLeave" skin="ghost" size="big">Button Label</v-button></td>
-              <td><v-button @mouseleave="onLeave" skin="text-primary" size="big">Button Label</v-button></td>
             </tr>
           </tbody>
         </table>
@@ -66,7 +63,7 @@ storiesOf('VButton/desktop', module)
           'success',
           'error',
           'quaternary-error',
-          'text-primary',
+          'ghost-error',
         ],
         skin: 'primary',
       };
@@ -318,44 +315,6 @@ storiesOf('VButton/desktop', module)
       </theme-provider>
     `,
   }))
-  .add('borderless', () => ({
-    methods,
-    components: { VButton },
-    template: `
-      <theme-provider>
-        <table width="100%">
-          <thead>
-            <tr>
-              <th></th>
-              <th>Primary</th>
-              <th>Secondary</th>
-              <th>Tertiary</th>
-              <th>Quaternary</th>
-              <th>Ghost</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th scope="row">Normal</th>
-              <td><v-button :isBorderless="true" @click="onClick">Button Label</v-button></td>
-              <td><v-button :isBorderless="true" @mouseenter="onEnter" skin="secondary">Button Label</v-button></td>
-              <td><v-button :isBorderless="true" @focus="onFocus" skin="tertiary">Button Label</v-button></td>
-              <td><v-button :isBorderless="true" @blur="onBlur" skin="quaternary">Button Label</v-button></td>
-              <td><v-button :isBorderless="true" @mouseleave="onLeave" skin="ghost">Button Label</v-button></td>
-            </tr>
-            <tr>
-              <th scope="row">Big</th>
-              <td><v-button :isBorderless="true" @click="onClick" size="big">Button Label</v-button></td>
-              <td><v-button :isBorderless="true" @mouseenter="onEnter" skin="secondary" size="big">Button Label</v-button></td>
-              <td><v-button :isBorderless="true" @focus="onFocus" skin="tertiary" size="big">Button Label</v-button></td>
-              <td><v-button :isBorderless="true" @blur="onBlur" skin="quaternary" size="big">Button Label</v-button></td>
-              <td><v-button :isBorderless="true" @mouseleave="onLeave" skin="ghost" size="big">Button Label</v-button></td>
-            </tr>
-          </tbody>
-        </table>
-      </theme-provider>
-    `,
-  }))
   .add('loading', () => ({
     methods,
     components: { VButton },
@@ -372,6 +331,7 @@ storiesOf('VButton/desktop', module)
               <th>Tertiary</th>
               <th>Quaternary</th>
               <th>Ghost</th>
+              <th>Ghost Error</th>
               <th>Social</th>
             </tr>
           </thead>
@@ -385,6 +345,7 @@ storiesOf('VButton/desktop', module)
               <td><v-button :isLoading="true" @focus="onFocus" skin="tertiary">Button Label</v-button></td>
               <td><v-button :isLoading="true" @blur="onBlur" skin="quaternary">Button Label</v-button></td>
               <td><v-button :isLoading="true" @mouseleave="onLeave" skin="ghost">Button Label</v-button></td>
+              <td><v-button :isLoading="true" @mouseleave="onLeave" skin="ghost-error">Button Label</v-button></td>
               <td>
                 <v-button :isLoading="true" @mouseleave="onLeave" skin="social">
                   <v-svg-icon name="github" style="margin-right: 5px;" slot="iconBefore" />
@@ -401,6 +362,7 @@ storiesOf('VButton/desktop', module)
               <td><v-button :isLoading="true" @focus="onFocus" skin="tertiary" size="big">Button Label</v-button></td>
               <td><v-button :isLoading="true" @blur="onBlur" skin="quaternary" size="big">Button Label</v-button></td>
               <td><v-button :isLoading="true" @mouseleave="onLeave" skin="ghost" size="big">Button Label</v-button></td>
+              <td><v-button :isLoading="true" @mouseleave="onLeave" skin="ghost-error" size="big">Button Label</v-button></td>
               <td>
                 <v-button :isLoading="true" @mouseleave="onLeave" skin="social" size="big">
                 <v-svg-icon name="github" style="margin-right: 5px;" slot="iconBefore" />

--- a/packages/ui/stories/VTag.stories.js
+++ b/packages/ui/stories/VTag.stories.js
@@ -86,6 +86,9 @@ storiesOf('VTag/desktop', module).add('default', () => ({
               <v-tag skin="light-gray">text tag</v-tag>
             </td>
             <td>
+              <v-tag skin="white">text tag</v-tag>
+            </td>
+            <td>
               <v-tag disabled>text tag</v-tag>
             </td>
           </tr>
@@ -120,6 +123,9 @@ storiesOf('VTag/desktop', module).add('default', () => ({
             </td>
             <td>
               <v-tag @click="onClick" is-closable  skin="light-gray">text tag</v-tag>
+            </td>
+            <td>
+              <v-tag @click="onClick" is-closable  skin="white">text tag</v-tag>
             </td>
             <td>
               <v-tag @click="onClick" is-closable  disabled>text tag</v-tag>

--- a/packages/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/packages/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -520,282 +520,6 @@ exports[`Storyshots VAccordion/desktop default 1`] = `
 </div>
 `;
 
-exports[`Storyshots VButton/desktop borderless 1`] = `
-<div>
-  <div
-    style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);"
-  />
-   
-  <table
-    width="100%"
-  >
-    <thead>
-      <tr>
-        <th />
-         
-        <th>
-          Primary
-        </th>
-         
-        <th>
-          Secondary
-        </th>
-         
-        <th>
-          Tertiary
-        </th>
-         
-        <th>
-          Quaternary
-        </th>
-         
-        <th>
-          Ghost
-        </th>
-      </tr>
-    </thead>
-     
-    <tbody>
-      <tr>
-        <th
-          scope="row"
-        >
-          Normal
-        </th>
-         
-        <td>
-          <button
-            class="v-button theme-default skin-primary size-normal is-borderless"
-          >
-            <!---->
-             
-            <!---->
-             
-            <span
-              class="v-button-label"
-            >
-              Button Label
-            </span>
-             
-            <!---->
-             
-            <!---->
-             
-            <!---->
-          </button>
-        </td>
-         
-        <td>
-          <button
-            class="v-button theme-default skin-secondary size-normal is-borderless"
-          >
-            <!---->
-             
-            <!---->
-             
-            <span
-              class="v-button-label"
-            >
-              Button Label
-            </span>
-             
-            <!---->
-             
-            <!---->
-             
-            <!---->
-          </button>
-        </td>
-         
-        <td>
-          <button
-            class="v-button theme-default skin-tertiary size-normal is-borderless"
-          >
-            <!---->
-             
-            <!---->
-             
-            <span
-              class="v-button-label"
-            >
-              Button Label
-            </span>
-             
-            <!---->
-             
-            <!---->
-             
-            <!---->
-          </button>
-        </td>
-         
-        <td>
-          <button
-            class="v-button theme-default skin-quaternary size-normal is-borderless"
-          >
-            <!---->
-             
-            <!---->
-             
-            <span
-              class="v-button-label"
-            >
-              Button Label
-            </span>
-             
-            <!---->
-             
-            <!---->
-             
-            <!---->
-          </button>
-        </td>
-         
-        <td>
-          <button
-            class="v-button theme-default skin-ghost size-normal is-borderless"
-          >
-            <!---->
-             
-            <!---->
-             
-            <span
-              class="v-button-label"
-            >
-              Button Label
-            </span>
-             
-            <!---->
-             
-            <!---->
-             
-            <!---->
-          </button>
-        </td>
-      </tr>
-       
-      <tr>
-        <th
-          scope="row"
-        >
-          Big
-        </th>
-         
-        <td>
-          <button
-            class="v-button theme-default skin-primary size-big is-borderless"
-          >
-            <!---->
-             
-            <!---->
-             
-            <span
-              class="v-button-label"
-            >
-              Button Label
-            </span>
-             
-            <!---->
-             
-            <!---->
-             
-            <!---->
-          </button>
-        </td>
-         
-        <td>
-          <button
-            class="v-button theme-default skin-secondary size-big is-borderless"
-          >
-            <!---->
-             
-            <!---->
-             
-            <span
-              class="v-button-label"
-            >
-              Button Label
-            </span>
-             
-            <!---->
-             
-            <!---->
-             
-            <!---->
-          </button>
-        </td>
-         
-        <td>
-          <button
-            class="v-button theme-default skin-tertiary size-big is-borderless"
-          >
-            <!---->
-             
-            <!---->
-             
-            <span
-              class="v-button-label"
-            >
-              Button Label
-            </span>
-             
-            <!---->
-             
-            <!---->
-             
-            <!---->
-          </button>
-        </td>
-         
-        <td>
-          <button
-            class="v-button theme-default skin-quaternary size-big is-borderless"
-          >
-            <!---->
-             
-            <!---->
-             
-            <span
-              class="v-button-label"
-            >
-              Button Label
-            </span>
-             
-            <!---->
-             
-            <!---->
-             
-            <!---->
-          </button>
-        </td>
-         
-        <td>
-          <button
-            class="v-button theme-default skin-ghost size-big is-borderless"
-          >
-            <!---->
-             
-            <!---->
-             
-            <span
-              class="v-button-label"
-            >
-              Button Label
-            </span>
-             
-            <!---->
-             
-            <!---->
-             
-            <!---->
-          </button>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-`;
-
 exports[`Storyshots VButton/desktop change-skin 1`] = `
 <div>
   <div
@@ -927,7 +651,7 @@ exports[`Storyshots VButton/desktop change-skin 1`] = `
     <span
       class=""
     >
-      text-primary
+      ghost-error
     </span>
              
         
@@ -1253,10 +977,6 @@ exports[`Storyshots VButton/desktop enabled 1`] = `
         <th>
           Ghost
         </th>
-         
-        <th>
-          Text Primary
-        </th>
       </tr>
     </thead>
      
@@ -1377,28 +1097,6 @@ exports[`Storyshots VButton/desktop enabled 1`] = `
             <!---->
           </button>
         </td>
-         
-        <td>
-          <button
-            class="v-button theme-default skin-text-primary size-normal"
-          >
-            <!---->
-             
-            <!---->
-             
-            <span
-              class="v-button-label"
-            >
-              Button Label
-            </span>
-             
-            <!---->
-             
-            <!---->
-             
-            <!---->
-          </button>
-        </td>
       </tr>
        
       <tr>
@@ -1499,28 +1197,6 @@ exports[`Storyshots VButton/desktop enabled 1`] = `
         <td>
           <button
             class="v-button theme-default skin-ghost size-big"
-          >
-            <!---->
-             
-            <!---->
-             
-            <span
-              class="v-button-label"
-            >
-              Button Label
-            </span>
-             
-            <!---->
-             
-            <!---->
-             
-            <!---->
-          </button>
-        </td>
-         
-        <td>
-          <button
-            class="v-button theme-default skin-text-primary size-big"
           >
             <!---->
              
@@ -2063,6 +1739,10 @@ exports[`Storyshots VButton/desktop loading 1`] = `
         </th>
          
         <th>
+          Ghost Error
+        </th>
+         
+        <th>
           Social
         </th>
       </tr>
@@ -2362,6 +2042,58 @@ exports[`Storyshots VButton/desktop loading 1`] = `
         <td>
           <button
             class="v-button theme-default skin-ghost size-normal"
+          >
+            <!---->
+             
+            <!---->
+             
+            <!---->
+             
+            <i
+              class="icon-atom v-button-icon theme-default"
+            >
+              <span
+                class="button-loader-atom theme-default"
+              >
+                <svg
+                  class="svg-atom theme-default"
+                  height="100%"
+                  width="100%"
+                >
+                  <use
+                    x="0"
+                    xlink:href="#endpass-ui-icon-empty"
+                    y="0"
+                  />
+                </svg>
+                 
+                <span
+                  class="button-loader-atom-spinner"
+                >
+                  <svg
+                    class="svg-atom theme-default"
+                    height="100%"
+                    width="100%"
+                  >
+                    <use
+                      x="0"
+                      xlink:href="#endpass-ui-icon-loader"
+                      y="0"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </i>
+             
+            <!---->
+             
+            <!---->
+          </button>
+        </td>
+         
+        <td>
+          <button
+            class="v-button theme-default skin-ghost-error size-normal"
           >
             <!---->
              
@@ -2761,6 +2493,58 @@ exports[`Storyshots VButton/desktop loading 1`] = `
         <td>
           <button
             class="v-button theme-default skin-ghost size-big"
+          >
+            <!---->
+             
+            <!---->
+             
+            <!---->
+             
+            <i
+              class="icon-atom v-button-icon theme-default"
+            >
+              <span
+                class="button-loader-atom theme-default"
+              >
+                <svg
+                  class="svg-atom theme-default"
+                  height="100%"
+                  width="100%"
+                >
+                  <use
+                    x="0"
+                    xlink:href="#endpass-ui-icon-empty"
+                    y="0"
+                  />
+                </svg>
+                 
+                <span
+                  class="button-loader-atom-spinner"
+                >
+                  <svg
+                    class="svg-atom theme-default"
+                    height="100%"
+                    width="100%"
+                  >
+                    <use
+                      x="0"
+                      xlink:href="#endpass-ui-icon-loader"
+                      y="0"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </i>
+             
+            <!---->
+             
+            <!---->
+          </button>
+        </td>
+         
+        <td>
+          <button
+            class="v-button theme-default skin-ghost-error size-big"
           >
             <!---->
              

--- a/packages/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/packages/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -520,6 +520,282 @@ exports[`Storyshots VAccordion/desktop default 1`] = `
 </div>
 `;
 
+exports[`Storyshots VButton/desktop borderless 1`] = `
+<div>
+  <div
+    style="position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);"
+  />
+   
+  <table
+    width="100%"
+  >
+    <thead>
+      <tr>
+        <th />
+         
+        <th>
+          Primary
+        </th>
+         
+        <th>
+          Secondary
+        </th>
+         
+        <th>
+          Tertiary
+        </th>
+         
+        <th>
+          Quaternary
+        </th>
+         
+        <th>
+          Ghost
+        </th>
+      </tr>
+    </thead>
+     
+    <tbody>
+      <tr>
+        <th
+          scope="row"
+        >
+          Normal
+        </th>
+         
+        <td>
+          <button
+            class="v-button theme-default skin-primary size-normal is-borderless"
+          >
+            <!---->
+             
+            <!---->
+             
+            <span
+              class="v-button-label"
+            >
+              Button Label
+            </span>
+             
+            <!---->
+             
+            <!---->
+             
+            <!---->
+          </button>
+        </td>
+         
+        <td>
+          <button
+            class="v-button theme-default skin-secondary size-normal is-borderless"
+          >
+            <!---->
+             
+            <!---->
+             
+            <span
+              class="v-button-label"
+            >
+              Button Label
+            </span>
+             
+            <!---->
+             
+            <!---->
+             
+            <!---->
+          </button>
+        </td>
+         
+        <td>
+          <button
+            class="v-button theme-default skin-tertiary size-normal is-borderless"
+          >
+            <!---->
+             
+            <!---->
+             
+            <span
+              class="v-button-label"
+            >
+              Button Label
+            </span>
+             
+            <!---->
+             
+            <!---->
+             
+            <!---->
+          </button>
+        </td>
+         
+        <td>
+          <button
+            class="v-button theme-default skin-quaternary size-normal is-borderless"
+          >
+            <!---->
+             
+            <!---->
+             
+            <span
+              class="v-button-label"
+            >
+              Button Label
+            </span>
+             
+            <!---->
+             
+            <!---->
+             
+            <!---->
+          </button>
+        </td>
+         
+        <td>
+          <button
+            class="v-button theme-default skin-ghost size-normal is-borderless"
+          >
+            <!---->
+             
+            <!---->
+             
+            <span
+              class="v-button-label"
+            >
+              Button Label
+            </span>
+             
+            <!---->
+             
+            <!---->
+             
+            <!---->
+          </button>
+        </td>
+      </tr>
+       
+      <tr>
+        <th
+          scope="row"
+        >
+          Big
+        </th>
+         
+        <td>
+          <button
+            class="v-button theme-default skin-primary size-big is-borderless"
+          >
+            <!---->
+             
+            <!---->
+             
+            <span
+              class="v-button-label"
+            >
+              Button Label
+            </span>
+             
+            <!---->
+             
+            <!---->
+             
+            <!---->
+          </button>
+        </td>
+         
+        <td>
+          <button
+            class="v-button theme-default skin-secondary size-big is-borderless"
+          >
+            <!---->
+             
+            <!---->
+             
+            <span
+              class="v-button-label"
+            >
+              Button Label
+            </span>
+             
+            <!---->
+             
+            <!---->
+             
+            <!---->
+          </button>
+        </td>
+         
+        <td>
+          <button
+            class="v-button theme-default skin-tertiary size-big is-borderless"
+          >
+            <!---->
+             
+            <!---->
+             
+            <span
+              class="v-button-label"
+            >
+              Button Label
+            </span>
+             
+            <!---->
+             
+            <!---->
+             
+            <!---->
+          </button>
+        </td>
+         
+        <td>
+          <button
+            class="v-button theme-default skin-quaternary size-big is-borderless"
+          >
+            <!---->
+             
+            <!---->
+             
+            <span
+              class="v-button-label"
+            >
+              Button Label
+            </span>
+             
+            <!---->
+             
+            <!---->
+             
+            <!---->
+          </button>
+        </td>
+         
+        <td>
+          <button
+            class="v-button theme-default skin-ghost size-big is-borderless"
+          >
+            <!---->
+             
+            <!---->
+             
+            <span
+              class="v-button-label"
+            >
+              Button Label
+            </span>
+             
+            <!---->
+             
+            <!---->
+             
+            <!---->
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`Storyshots VButton/desktop change-skin 1`] = `
 <div>
   <div
@@ -641,6 +917,17 @@ exports[`Storyshots VButton/desktop change-skin 1`] = `
       class=""
     >
       quaternary-error
+    </span>
+             
+        
+  </span>
+  <span>
+    
+           
+    <span
+      class=""
+    >
+      text-primary
     </span>
              
         
@@ -966,6 +1253,10 @@ exports[`Storyshots VButton/desktop enabled 1`] = `
         <th>
           Ghost
         </th>
+         
+        <th>
+          Text Primary
+        </th>
       </tr>
     </thead>
      
@@ -1086,6 +1377,28 @@ exports[`Storyshots VButton/desktop enabled 1`] = `
             <!---->
           </button>
         </td>
+         
+        <td>
+          <button
+            class="v-button theme-default skin-text-primary size-normal"
+          >
+            <!---->
+             
+            <!---->
+             
+            <span
+              class="v-button-label"
+            >
+              Button Label
+            </span>
+             
+            <!---->
+             
+            <!---->
+             
+            <!---->
+          </button>
+        </td>
       </tr>
        
       <tr>
@@ -1186,6 +1499,28 @@ exports[`Storyshots VButton/desktop enabled 1`] = `
         <td>
           <button
             class="v-button theme-default skin-ghost size-big"
+          >
+            <!---->
+             
+            <!---->
+             
+            <span
+              class="v-button-label"
+            >
+              Button Label
+            </span>
+             
+            <!---->
+             
+            <!---->
+             
+            <!---->
+          </button>
+        </td>
+         
+        <td>
+          <button
+            class="v-button theme-default skin-text-primary size-big"
           >
             <!---->
              
@@ -11316,6 +11651,15 @@ exports[`Storyshots VTag/desktop default 1`] = `
        
       <td>
         <div
+          class="v-tag theme-default skin-white"
+        >
+          text tag 
+          <!---->
+        </div>
+      </td>
+       
+      <td>
+        <div
           class="v-tag theme-default skin-default"
           disabled="disabled"
         >
@@ -11540,6 +11884,29 @@ exports[`Storyshots VTag/desktop default 1`] = `
       <td>
         <div
           class="v-tag theme-default is-closable skin-light-gray"
+        >
+          text tag 
+          <i
+            class="icon-atom v-tag-close theme-default"
+          >
+            <svg
+              class="svg-atom theme-default"
+              height="100%"
+              width="100%"
+            >
+              <use
+                x="0"
+                xlink:href="#endpass-ui-icon-close"
+                y="0"
+              />
+            </svg>
+          </i>
+        </div>
+      </td>
+       
+      <td>
+        <div
+          class="v-tag theme-default is-closable skin-white"
         >
           text tag 
           <i


### PR DESCRIPTION
According to the Figma we need add some new skins for tags and buttons in the ui.
- Did add `white` skin for `VTag` component, which represents tag with transparent background, gray text and gray border
- Did add `text-primary` skin for `VButton` component, which represents button without background, borders and shadows