### PR TITLE
fix(ui): make accordion height dynamic and add support of multiline title

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endpass/ui",
-  "version": "0.15.79",
+  "version": "0.15.80",
   "description": "UI components",
   "author": "Endpass, Inc",
   "homepage": "http://endpass.com/",

--- a/packages/ui/src/kit/VAccordion/VAccordionItem/VAccordionItem.theme-default.scss
+++ b/packages/ui/src/kit/VAccordion/VAccordionItem/VAccordionItem.theme-default.scss
@@ -38,7 +38,7 @@
     align-items: center;
 
     padding: 0 12px;
-    height: 40px;
+    min-height: 40px;
 
     cursor: pointer;
     transition: all 150ms ease-in-out;
@@ -49,6 +49,8 @@
     color: var(--endpass-ui-color-black);
     font-size: 1em;
     font-weight: bolder;
+    padding: 8px 0;
+    line-height: 1.2;
   }
 
   .v-accordion-content {


### PR DESCRIPTION
In accordions there are cases when item have more than one lines of text. Earlier, accordion don't handle these cases properly, and multiline text causes overflow.
- did add support for multiline text inside accordion items
- minor formatting fix for multiline text: line height, padding, etc