### PR TITLE
feat(ui): dark gray skin for tags

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endpass/ui",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "UI components",
   "author": "Endpass, Inc",
   "homepage": "http://endpass.com/",

--- a/packages/ui/src/kit/VTag/VTag.theme-default.scss
+++ b/packages/ui/src/kit/VTag/VTag.theme-default.scss
@@ -83,6 +83,11 @@
   background-color: var(--endpass-ui-color-grey-1);
 }
 
+.v-tag.theme-default.skin-dark-gray {
+  color: var(--endpass-ui-color-white);
+  background-color: var(--endpass-ui-color-grey-8);
+}
+
 .v-tag.theme-default.skin-white {
   border-color: var(--endpass-ui-color-grey-3);
   color: var(--endpass-ui-color-grey-9);

--- a/packages/ui/src/kit/VTag/VTag.vue
+++ b/packages/ui/src/kit/VTag/VTag.vue
@@ -44,6 +44,7 @@ export default {
             'green',
             'gray',
             'light-gray',
+            'dark-gray',
             'white',
           ].indexOf(value) !== -1
         );

--- a/packages/ui/stories/VTag.stories.js
+++ b/packages/ui/stories/VTag.stories.js
@@ -49,6 +49,9 @@ storiesOf('VTag/desktop', module).add('default', () => ({
                 light-gray
               </th>
               <th>
+                dark-gray
+              </th>
+              <th>
                 disabled
               </th>
             </tr>
@@ -84,6 +87,9 @@ storiesOf('VTag/desktop', module).add('default', () => ({
             </td>
             <td>
               <v-tag skin="light-gray">text tag</v-tag>
+            </td>
+            <td>
+              <v-tag skin="dark-gray">text tag</v-tag>
             </td>
             <td>
               <v-tag skin="white">text tag</v-tag>
@@ -123,6 +129,9 @@ storiesOf('VTag/desktop', module).add('default', () => ({
             </td>
             <td>
               <v-tag @click="onClick" is-closable  skin="light-gray">text tag</v-tag>
+            </td>
+            <td>
+              <v-tag @click="onClick" is-closable  skin="dark-gray">text tag</v-tag>
             </td>
             <td>
               <v-tag @click="onClick" is-closable  skin="white">text tag</v-tag>

--- a/packages/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/packages/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -11966,6 +11966,12 @@ exports[`Storyshots VTag/desktop default 1`] = `
          
         <th>
           
+                dark-gray
+              
+        </th>
+         
+        <th>
+          
                 disabled
               
         </th>
@@ -12061,6 +12067,15 @@ exports[`Storyshots VTag/desktop default 1`] = `
       <td>
         <div
           class="v-tag theme-default skin-light-gray"
+        >
+          text tag 
+          <!---->
+        </div>
+      </td>
+       
+      <td>
+        <div
+          class="v-tag theme-default skin-dark-gray"
         >
           text tag 
           <!---->
@@ -12302,6 +12317,29 @@ exports[`Storyshots VTag/desktop default 1`] = `
       <td>
         <div
           class="v-tag theme-default is-closable skin-light-gray"
+        >
+          text tag 
+          <i
+            class="icon-atom v-tag-close theme-default"
+          >
+            <svg
+              class="svg-atom theme-default"
+              height="100%"
+              width="100%"
+            >
+              <use
+                x="0"
+                xlink:href="#endpass-ui-icon-close"
+                y="0"
+              />
+            </svg>
+          </i>
+        </div>
+      </td>
+       
+      <td>
+        <div
+          class="v-tag theme-default is-closable skin-dark-gray"
         >
           text tag 
           <i


### PR DESCRIPTION
Did add new skin for `VTag` component, `dark-gray`, according to latest design. This skin uses color named `gray-8` and white text.