### PR TITLE
fix: adjust tooltips position for radio

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@endpass/ui",
-  "version": "0.18.14",
+  "version": "0.18.15",
   "description": "UI components",
   "author": "Endpass, Inc",
   "homepage": "http://endpass.com/",

--- a/packages/ui/src/kit/VRadio/VRadio.theme-default.scss
+++ b/packages/ui/src/kit/VRadio/VRadio.theme-default.scss
@@ -9,10 +9,6 @@
   color: var(--endpass-ui-color-grey-4);
 }
 
-.v-radio.theme-default .v-radio-tooltip {
-  margin-top: 2px;
-}
-
 .v-radio.theme-default .v-radio-input {
   display: none;
 }

--- a/packages/ui/src/kit/VRadio/VRadio.theme-default.scss
+++ b/packages/ui/src/kit/VRadio/VRadio.theme-default.scss
@@ -9,6 +9,10 @@
   color: var(--endpass-ui-color-grey-4);
 }
 
+.v-radio.theme-default .v-radio-tooltip {
+  margin-top: 2px;
+}
+
 .v-radio.theme-default .v-radio-input {
   display: none;
 }

--- a/packages/ui/src/kit/VRadio/VRadio.vue
+++ b/packages/ui/src/kit/VRadio/VRadio.vue
@@ -14,10 +14,9 @@
     >
       <slot />
     </span>
-    <tooltip-molecule
-      class="v-radio-tooltip"
-      :label="tooltipLabel"
-    />
+    <div>
+      <tooltip-molecule :label="tooltipLabel" />
+    </div>
   </label>
 </template>
 

--- a/packages/ui/src/kit/VRadio/VRadio.vue
+++ b/packages/ui/src/kit/VRadio/VRadio.vue
@@ -14,7 +14,10 @@
     >
       <slot />
     </span>
-    <tooltip-molecule :label="tooltipLabel" />
+    <tooltip-molecule
+      class="v-radio-tooltip"
+      :label="tooltipLabel"
+    />
   </label>
 </template>
 

--- a/packages/ui/src/molecule/label-molecule/label-molecule.theme-default.scss
+++ b/packages/ui/src/molecule/label-molecule/label-molecule.theme-default.scss
@@ -3,12 +3,12 @@
   vertical-align: sub;
   width: 14px;
   height: 14px;
+  line-height: 1;
 }
 
 .label-molecule.theme-default .label-molecule-icon {
   display: inline-block;
   font-size: 14px;
-  line-height: 1;
   width: 14px;
   height: 14px;
   text-align: center;

--- a/packages/ui/src/molecule/tooltip-molecule/tooltip-molecule.theme-default.scss
+++ b/packages/ui/src/molecule/tooltip-molecule/tooltip-molecule.theme-default.scss
@@ -3,12 +3,12 @@
   vertical-align: sub;
   width: 14px;
   height: 14px;
+  line-height: 1;
 }
 
 .tooltip-molecule.theme-default .tooltip-molecule-icon {
   display: inline-block;
   font-size: 14px;
-  line-height: 1;
   width: 14px;
   height: 14px;
   text-align: center;

--- a/packages/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/packages/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -9262,7 +9262,9 @@ exports[`Storyshots VRadio/desktop default 1`] = `
       
     </span>
      
-    <!---->
+    <div>
+      <!---->
+    </div>
   </label>
    
   <label
@@ -9287,7 +9289,9 @@ exports[`Storyshots VRadio/desktop default 1`] = `
       
     </span>
      
-    <!---->
+    <div>
+      <!---->
+    </div>
   </label>
    
   <label
@@ -9312,37 +9316,39 @@ exports[`Storyshots VRadio/desktop default 1`] = `
       
     </span>
      
-    <div
-      class="tooltip-molecule v-radio-tooltip theme-default"
-    >
+    <div>
       <div
-        class="tooltip-atom theme-default position-bottom-left"
-        style="display: none;"
+        class="tooltip-molecule theme-default"
       >
         <div
-          class="tooltip-atom-container"
+          class="tooltip-atom theme-default position-bottom-left"
+          style="display: none;"
         >
-          
+          <div
+            class="tooltip-atom-container"
+          >
+            
     with tooltip
   
+          </div>
         </div>
-      </div>
-       
-      <i
-        class="icon-atom tooltip-molecule-icon theme-default"
-      >
-        <svg
-          class="svg-atom theme-default"
-          height="100%"
-          width="100%"
+         
+        <i
+          class="icon-atom tooltip-molecule-icon theme-default"
         >
-          <use
-            x="0"
-            xlink:href="#endpass-ui-icon-info"
-            y="0"
-          />
-        </svg>
-      </i>
+          <svg
+            class="svg-atom theme-default"
+            height="100%"
+            width="100%"
+          >
+            <use
+              x="0"
+              xlink:href="#endpass-ui-icon-info"
+              y="0"
+            />
+          </svg>
+        </i>
+      </div>
     </div>
   </label>
 </div>
@@ -9382,7 +9388,9 @@ exports[`Storyshots VRadio/desktop disabled 1`] = `
       
     </span>
      
-    <!---->
+    <div>
+      <!---->
+    </div>
   </label>
    
   <label
@@ -9409,7 +9417,9 @@ exports[`Storyshots VRadio/desktop disabled 1`] = `
       
     </span>
      
-    <!---->
+    <div>
+      <!---->
+    </div>
   </label>
    
   <label
@@ -9436,37 +9446,39 @@ exports[`Storyshots VRadio/desktop disabled 1`] = `
       
     </span>
      
-    <div
-      class="tooltip-molecule v-radio-tooltip theme-default"
-    >
+    <div>
       <div
-        class="tooltip-atom theme-default position-bottom-left"
-        style="display: none;"
+        class="tooltip-molecule theme-default"
       >
         <div
-          class="tooltip-atom-container"
+          class="tooltip-atom theme-default position-bottom-left"
+          style="display: none;"
         >
-          
+          <div
+            class="tooltip-atom-container"
+          >
+            
     with tooltip
   
+          </div>
         </div>
-      </div>
-       
-      <i
-        class="icon-atom tooltip-molecule-icon theme-default"
-      >
-        <svg
-          class="svg-atom theme-default"
-          height="100%"
-          width="100%"
+         
+        <i
+          class="icon-atom tooltip-molecule-icon theme-default"
         >
-          <use
-            x="0"
-            xlink:href="#endpass-ui-icon-info"
-            y="0"
-          />
-        </svg>
-      </i>
+          <svg
+            class="svg-atom theme-default"
+            height="100%"
+            width="100%"
+          >
+            <use
+              x="0"
+              xlink:href="#endpass-ui-icon-info"
+              y="0"
+            />
+          </svg>
+        </i>
+      </div>
     </div>
   </label>
 </div>
@@ -9504,7 +9516,9 @@ exports[`Storyshots VRadio/desktop error 1`] = `
       
     </span>
      
-    <!---->
+    <div>
+      <!---->
+    </div>
   </label>
    
   <label
@@ -9529,7 +9543,9 @@ exports[`Storyshots VRadio/desktop error 1`] = `
       
     </span>
      
-    <!---->
+    <div>
+      <!---->
+    </div>
   </label>
    
   <label
@@ -9554,37 +9570,39 @@ exports[`Storyshots VRadio/desktop error 1`] = `
       
     </span>
      
-    <div
-      class="tooltip-molecule v-radio-tooltip theme-default"
-    >
+    <div>
       <div
-        class="tooltip-atom theme-default position-bottom-left"
-        style="display: none;"
+        class="tooltip-molecule theme-default"
       >
         <div
-          class="tooltip-atom-container"
+          class="tooltip-atom theme-default position-bottom-left"
+          style="display: none;"
         >
-          
+          <div
+            class="tooltip-atom-container"
+          >
+            
     with tooltip
   
+          </div>
         </div>
-      </div>
-       
-      <i
-        class="icon-atom tooltip-molecule-icon theme-default"
-      >
-        <svg
-          class="svg-atom theme-default"
-          height="100%"
-          width="100%"
+         
+        <i
+          class="icon-atom tooltip-molecule-icon theme-default"
         >
-          <use
-            x="0"
-            xlink:href="#endpass-ui-icon-info"
-            y="0"
-          />
-        </svg>
-      </i>
+          <svg
+            class="svg-atom theme-default"
+            height="100%"
+            width="100%"
+          >
+            <use
+              x="0"
+              xlink:href="#endpass-ui-icon-info"
+              y="0"
+            />
+          </svg>
+        </i>
+      </div>
     </div>
   </label>
 </div>

--- a/packages/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/packages/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -9313,7 +9313,7 @@ exports[`Storyshots VRadio/desktop default 1`] = `
     </span>
      
     <div
-      class="tooltip-molecule theme-default"
+      class="tooltip-molecule v-radio-tooltip theme-default"
     >
       <div
         class="tooltip-atom theme-default position-bottom-left"
@@ -9437,7 +9437,7 @@ exports[`Storyshots VRadio/desktop disabled 1`] = `
     </span>
      
     <div
-      class="tooltip-molecule theme-default"
+      class="tooltip-molecule v-radio-tooltip theme-default"
     >
       <div
         class="tooltip-atom theme-default position-bottom-left"
@@ -9555,7 +9555,7 @@ exports[`Storyshots VRadio/desktop error 1`] = `
     </span>
      
     <div
-      class="tooltip-molecule theme-default"
+      class="tooltip-molecule v-radio-tooltip theme-default"
     >
       <div
         class="tooltip-atom theme-default position-bottom-left"


### PR DESCRIPTION
Did fix tooltip position for radio component. Issue reason was in 2px margin that adds to radio label, but not adds for tooltip, so even correct middle alignmnent is not correct.